### PR TITLE
🔐 Fix OIDC documentation to use GitHub secrets instead of variables

### DIFF
--- a/OIDC-SETUP.md
+++ b/OIDC-SETUP.md
@@ -61,20 +61,20 @@ az ad app federated-credential create --id YOUR_CLIENT_ID --parameters '{
 }'
 ```
 
-### 3. Set GitHub Repository Variables
+### 3. Set GitHub Repository Secrets
 
-Use GitHub CLI to set **public variables** (not secrets):
+Use GitHub CLI to set **secrets** (these contain sensitive information):
 
 ```bash
-# Set repository variables (these are not sensitive)
-gh variable set AZURE_CLIENT_ID --body "YOUR_CLIENT_ID"
-gh variable set AZURE_TENANT_ID --body "YOUR_TENANT_ID" 
-gh variable set AZURE_SUBSCRIPTION_ID --body "YOUR_SUBSCRIPTION_ID"
+# Set repository secrets for sensitive Azure identifiers
+gh secret set AZURE_CLIENT_ID --body "YOUR_CLIENT_ID"
+gh secret set AZURE_TENANT_ID --body "YOUR_TENANT_ID" 
+gh secret set AZURE_SUBSCRIPTION_ID --body "YOUR_SUBSCRIPTION_ID"
 ```
 
 Or set them via GitHub web interface:
-- Go to **Settings** → **Secrets and variables** → **Actions** → **Variables** tab
-- Add the three variables above
+- Go to **Settings** → **Secrets and variables** → **Actions** → **Secrets** tab
+- Add the three secrets above
 
 ### 4. Update Workflow Configuration
 
@@ -93,9 +93,9 @@ And this authentication configuration:
 - name: Azure Login
   uses: azure/login@v2
   with:
-    client-id: ${{ vars.AZURE_CLIENT_ID }}
-    tenant-id: ${{ vars.AZURE_TENANT_ID }}
-    subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+    client-id: ${{ secrets.AZURE_CLIENT_ID }}
+    tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+    subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 ```
 
 ## 🔍 Verification


### PR DESCRIPTION
## 🎯 Purpose
Fixes a critical security documentation issue in OIDC-SETUP.md where Azure authentication identifiers were incorrectly documented as GitHub variables instead of secrets.

## 🔐 Security Enhancement
- **Fixed**: Updated documentation to use GitHub **secrets** for Azure identifiers
- **Changed**: \gh variable set\ → \gh secret set\ in CLI examples  
- **Updated**: Workflow examples to use \secrets.AZURE_*\ instead of \ars.AZURE_*\
- **Corrected**: Web interface instructions to point to Secrets tab

## 🚨 Why This Matters
| Item | Variables (❌ Wrong) | Secrets (✅ Correct) |
|------|---------------------|---------------------|
| **Visibility** | Public to all repo collaborators | Encrypted, hidden from logs/UI |
| **Security** | Exposed in plain text | Protected and masked |
| **Best Practice** | Not for sensitive data | Designed for credentials |

## 📋 Changes Made
- \AZURE_CLIENT_ID\ → Now correctly uses secrets
- \AZURE_TENANT_ID\ → Now correctly uses secrets  
- \AZURE_SUBSCRIPTION_ID\ → Now correctly uses secrets
- Updated all CLI commands and workflow examples
- Fixed web interface navigation instructions

## ✅ Validation
- [x] Documentation follows GitHub security best practices
- [x] All examples use proper secret syntax
- [x] CLI commands reference correct GitHub CLI secret commands
- [x] No sensitive information exposed in variables

This ensures proper security posture for Azure OIDC authentication in GitHub Actions! 🛡️