### PR TITLE
feat: Azure DriftGuard v4.0.0 Rebrand

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Azure Configuration Drift Detection Project
+# DriftGuard Project
 
 This C# console application compares Bicep/ARM template configurations with live Azure resources to detect configuration drift and automatically remediate it.
 

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,12 +1,12 @@
 # GitHub Actions Scripts
 
-This directory contains utility scripts used by the GitHub Actions workflows for the Azure Drift Detector project.
+This directory contains utility scripts used by the GitHub Actions workflows for DriftGuard.
 
 ## Scripts
 
 ### `check-drift.sh`
 
-**Purpose**: Executes the Azure Drift Detector and extracts JSON drift reports
+**Purpose**: Executes DriftGuard and extracts JSON drift reports
 
 **Usage**:
 ```bash

--- a/.github/scripts/check-drift.sh
+++ b/.github/scripts/check-drift.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Azure Drift Detection Script
+# DriftGuard Detection Script
 # This script runs the drift detector and extracts the JSON report
 
 set -e  # Exit on any error
@@ -10,7 +10,7 @@ RESOURCE_GROUP="$2"
 OUTPUT_FILE="${3:-drift-report.json}"
 IGNORE_CONFIG="$4"
 
-echo "🔍 Running drift detection..."
+echo "🔍 Running DriftGuard..."
 echo "📄 Template: $TEMPLATE_FILE"
 echo "🏗️  Resource Group: $RESOURCE_GROUP"
 echo "📊 Output File: $OUTPUT_FILE"
@@ -25,8 +25,8 @@ if [ -n "$IGNORE_CONFIG" ] && [ -f "$IGNORE_CONFIG" ]; then
 fi
 
 # Run drift detector with JSON output
-echo "🚀 Executing drift detector..."
-eval "dotnet run --no-build --configuration Release --project AzureDriftDetector.csproj -- $ARGS" > full-output.txt 2>&1 || true
+echo "🚀 Executing DriftGuard..."
+eval "dotnet run --no-build --configuration Release --project DriftGuard.csproj -- $ARGS" > full-output.txt 2>&1 || true
 
 # Check if output file was created
 if [ ! -f full-output.txt ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
     - name: 📦 Restore dependencies
-      run: dotnet restore AzureDriftDetector.csproj
+      run: dotnet restore DriftGuard.csproj
       
     - name: 🔧 Build solution
-      run: dotnet build AzureDriftDetector.csproj --no-restore --configuration Release
+      run: dotnet build DriftGuard.csproj --no-restore --configuration Release
       
     - name: 🧪 Run unit tests
       run: echo "⚠️ Tests temporarily disabled - fixing xUnit reference issues" 
@@ -44,16 +44,16 @@ jobs:
       if: always()
       with:
         name: test-results
-        path: tests/AzureDriftDetector.Tests/TestResults/test-results.trx
+        path: tests/DriftGuard.Tests/TestResults/test-results.trx
         retention-days: 30
       continue-on-error: true
       
     - name: 🎯 Check code formatting
-      run: dotnet format AzureDriftDetector.csproj --verify-no-changes --verbosity diagnostic
+      run: dotnet format DriftGuard.csproj --verify-no-changes --verbosity diagnostic
       continue-on-error: true # Don't fail on formatting issues for now
       
     - name: 📋 Run code analysis
-      run: dotnet build AzureDriftDetector.csproj --configuration Release --verbosity normal
+      run: dotnet build DriftGuard.csproj --configuration Release --verbosity normal
       
   build-and-test:
     name: 🏗️ Build & Test
@@ -72,10 +72,10 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
     - name: 📦 Restore dependencies
-      run: dotnet restore AzureDriftDetector.csproj
+      run: dotnet restore DriftGuard.csproj
       
     - name: 🔧 Build project
-      run: dotnet build AzureDriftDetector.csproj --no-restore --configuration Release
+      run: dotnet build DriftGuard.csproj --no-restore --configuration Release
       
     - name: ✅ Build Status
       run: echo "🎉 Build successful on ${{ matrix.os }}!"
@@ -100,8 +100,8 @@ jobs:
         
     - name: 🔍 Run security analysis
       run: |
-        dotnet list AzureDriftDetector.csproj package --vulnerable --include-transitive || true
-        dotnet list AzureDriftDetector.csproj package --deprecated || true
+        dotnet list DriftGuard.csproj package --vulnerable --include-transitive || true
+        dotnet list DriftGuard.csproj package --deprecated || true
         
     - name: 🛡️ Initialize CodeQL
       uses: github/codeql-action/init@v4
@@ -110,10 +110,10 @@ jobs:
       continue-on-error: true
         
     - name: 📦 Restore dependencies for analysis
-      run: dotnet restore AzureDriftDetector.csproj
+      run: dotnet restore DriftGuard.csproj
         
     - name: 🔧 Build for analysis
-      run: dotnet build AzureDriftDetector.csproj --configuration Release --no-restore
+      run: dotnet build DriftGuard.csproj --configuration Release --no-restore
       
     - name: 🔍 Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
@@ -167,18 +167,18 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
     - name: 📦 Restore dependencies
-      run: dotnet restore AzureDriftDetector.csproj
+      run: dotnet restore DriftGuard.csproj
       
     - name: 🏗️ Build for multiple platforms
       run: |
         # Build for Windows x64
-        dotnet publish AzureDriftDetector.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o ./artifacts/win-x64
+        dotnet publish DriftGuard.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o ./artifacts/win-x64
         
         # Build for Linux x64
-        dotnet publish AzureDriftDetector.csproj -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o ./artifacts/linux-x64
+        dotnet publish DriftGuard.csproj -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o ./artifacts/linux-x64
         
         # Build for macOS x64
-        dotnet publish AzureDriftDetector.csproj -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -o ./artifacts/osx-x64
+        dotnet publish DriftGuard.csproj -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -o ./artifacts/osx-x64
         
     - name: 📋 Create build info
       run: |
@@ -207,7 +207,7 @@ jobs:
       if: needs.lint-format-and-test.result == 'success' && needs.build-and-test.result == 'success' && needs.security-analysis.result == 'success' && needs.validate-bicep.result == 'success'
       run: |
         echo "✅ All quality checks passed!"
-        echo "🎉 Azure Configuration Drift Detector is ready for deployment!"
+        echo "🎉 DriftGuard is ready for deployment!"
         
     - name: ❌ Report Failure
       if: needs.lint-format-and-test.result == 'failure' || needs.build-and-test.result == 'failure' || needs.security-analysis.result == 'failure' || needs.validate-bicep.result == 'failure'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,10 +40,10 @@ jobs:
         queries: security-extended,security-and-quality
 
     - name: 📦 Restore dependencies
-      run: dotnet restore AzureDriftDetector.csproj
+      run: dotnet restore DriftGuard.csproj
 
     - name: 🔧 Build project
-      run: dotnet build AzureDriftDetector.csproj --configuration Release --no-restore
+      run: dotnet build DriftGuard.csproj --configuration Release --no-restore
 
     - name: 🔍 Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/drift-monitoring.yml
+++ b/.github/workflows/drift-monitoring.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         environment: 
-          - { name: 'dev', resource_group: 'dev', template: 'samples/main-template.bicepparam' }
+          - { name: 'dev', resource_group: 'rg-driftguard-dev', template: 'samples/main-template.bicepparam' }
       fail-fast: false
       
     name: Monitor ${{ matrix.environment.name }}

--- a/.github/workflows/drift-monitoring.yml
+++ b/.github/workflows/drift-monitoring.yml
@@ -53,8 +53,8 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: Build Drift Detector
-      run: dotnet build AzureDriftDetector.csproj --configuration Release
+    - name: Build DriftGuard
+      run: dotnet build DriftGuard.csproj --configuration Release
 
     - name: Check Drift
       id: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         git push origin "v${{ steps.version.outputs.version }}"
         
     - name: 📦 Restore dependencies
-      run: dotnet restore AzureDriftDetector.csproj
+      run: dotnet restore DriftGuard.csproj
       
     - name: 🏗️ Build release artifacts
       run: |
@@ -68,20 +68,20 @@ jobs:
         mkdir -p release-artifacts
         
         # Build for Windows x64
-        dotnet publish AzureDriftDetector.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o ./temp/win-x64
-        zip -r release-artifacts/AzureDriftDetector-${{ steps.version.outputs.version }}-win-x64.zip ./temp/win-x64/
+        dotnet publish DriftGuard.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -o ./temp/win-x64
+        zip -r release-artifacts/DriftGuard-${{ steps.version.outputs.version }}-win-x64.zip ./temp/win-x64/
         
         # Build for Linux x64  
-        dotnet publish AzureDriftDetector.csproj -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o ./temp/linux-x64
-        tar -czf release-artifacts/AzureDriftDetector-${{ steps.version.outputs.version }}-linux-x64.tar.gz -C ./temp/linux-x64 .
+        dotnet publish DriftGuard.csproj -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -o ./temp/linux-x64
+        tar -czf release-artifacts/DriftGuard-${{ steps.version.outputs.version }}-linux-x64.tar.gz -C ./temp/linux-x64 .
         
         # Build for macOS x64
-        dotnet publish AzureDriftDetector.csproj -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -o ./temp/osx-x64
-        zip -r release-artifacts/AzureDriftDetector-${{ steps.version.outputs.version }}-osx-x64.zip ./temp/osx-x64/
+        dotnet publish DriftGuard.csproj -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -o ./temp/osx-x64
+        zip -r release-artifacts/DriftGuard-${{ steps.version.outputs.version }}-osx-x64.zip ./temp/osx-x64/
         
         # Create portable .NET version (requires .NET runtime)
-        dotnet publish AzureDriftDetector.csproj -c Release --no-self-contained -o ./temp/portable
-        zip -r release-artifacts/AzureDriftDetector-${{ steps.version.outputs.version }}-portable.zip ./temp/portable/
+        dotnet publish DriftGuard.csproj -c Release --no-self-contained -o ./temp/portable
+        zip -r release-artifacts/DriftGuard-${{ steps.version.outputs.version }}-portable.zip ./temp/portable/
         
     - name: 📋 Generate release notes
       id: changelog
@@ -99,7 +99,7 @@ jobs:
         
         # Create release notes
         cat > release_notes.md << EOF
-        # Azure Configuration Drift Detector v${{ steps.version.outputs.version }}
+        # DriftGuard v${{ steps.version.outputs.version }}
         
         ## 🎯 What's New
         
@@ -113,16 +113,16 @@ jobs:
         
         Choose the appropriate package for your platform:
         
-        - **Windows x64**: \`AzureDriftDetector-${{ steps.version.outputs.version }}-win-x64.zip\` (Self-contained executable)
-        - **Linux x64**: \`AzureDriftDetector-${{ steps.version.outputs.version }}-linux-x64.tar.gz\` (Self-contained executable)
-        - **macOS x64**: \`AzureDriftDetector-${{ steps.version.outputs.version }}-osx-x64.zip\` (Self-contained executable)
-        - **Portable**: \`AzureDriftDetector-${{ steps.version.outputs.version }}-portable.zip\` (Requires .NET 8 runtime)
+        - **Windows x64**: \`DriftGuard-${{ steps.version.outputs.version }}-win-x64.zip\` (Self-contained executable)
+        - **Linux x64**: \`DriftGuard-${{ steps.version.outputs.version }}-linux-x64.tar.gz\` (Self-contained executable)
+        - **macOS x64**: \`DriftGuard-${{ steps.version.outputs.version }}-osx-x64.zip\` (Self-contained executable)
+        - **Portable**: \`DriftGuard-${{ steps.version.outputs.version }}-portable.zip\` (Requires .NET 8 runtime)
         
         ## 🚀 Quick Start
         
         1. Download the appropriate package for your platform
         2. Extract the archive
-        3. Run: \`./AzureDriftDetector --bicep-file template.bicep --resource-group myResourceGroup\`
+        3. Run: \`./DriftGuard --bicep-file template.bicep --resource-group myResourceGroup\`
         
         ## ✨ Key Features
         
@@ -147,7 +147,7 @@ jobs:
     - name: 🚀 Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        name: Azure Configuration Drift Detector v${{ steps.version.outputs.version }}
+        name: DriftGuard v${{ steps.version.outputs.version }}
         body: ${{ steps.changelog.outputs.release_notes }}
         files: release-artifacts/*
         draft: false

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "Build Azure Drift Detector",
+			"label": "Build DriftGuard",
 			"type": "shell",
 			"command": "dotnet",
 			"args": [

--- a/Core/DriftDetector.cs
+++ b/Core/DriftDetector.cs
@@ -1,7 +1,7 @@
-using AzureDriftDetector.Models;
-using AzureDriftDetector.Services;
+using DriftGuard.Models;
+using DriftGuard.Services;
 
-namespace AzureDriftDetector.Core;
+namespace DriftGuard.Core;
 
 public class DriftDetector
 {

--- a/DriftGuard.csproj
+++ b/DriftGuard.csproj
@@ -5,10 +5,10 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.6.0</Version>
-    <AssemblyVersion>3.6.0.0</AssemblyVersion>
-    <FileVersion>3.6.0.0</FileVersion>
-    <Product>DriftGuard</Product>
+    <Version>4.0.0</Version>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <FileVersion>4.0.0.0</FileVersion>
+    <Product>Azure DriftGuard</Product>
     <Description>Detects configuration drift between Bicep templates and live Azure resources</Description>
   </PropertyGroup>
 

--- a/DriftGuard.csproj
+++ b/DriftGuard.csproj
@@ -8,8 +8,8 @@
     <Version>3.6.0</Version>
     <AssemblyVersion>3.6.0.0</AssemblyVersion>
     <FileVersion>3.6.0.0</FileVersion>
-    <Product>Azure Configuration Drift Detector</Product>
-    <Description>Detects and automatically fixes configuration drift between Bicep templates and live Azure resources</Description>
+    <Product>DriftGuard</Product>
+    <Description>Detects configuration drift between Bicep templates and live Azure resources</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DriftGuard.sln
+++ b/DriftGuard.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureDriftDetector", "AzureDriftDetector.csproj", "{321EB496-7CE5-FA1C-EFAA-E641532EF269}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DriftGuard", "DriftGuard.csproj", "{321EB496-7CE5-FA1C-EFAA-E641532EF269}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License
 
-Copyright (c) 2025 Azure Configuration Drift Detector Contributors
+Copyright (c) 2025 DriftGuard Contributors
 
 This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License.
 

--- a/Models/DriftModels.cs
+++ b/Models/DriftModels.cs
@@ -1,4 +1,4 @@
-namespace AzureDriftDetector.Models;
+namespace DriftGuard.Models;
 
 public enum OutputFormat
 {

--- a/Program.cs
+++ b/Program.cs
@@ -1,16 +1,16 @@
-using AzureDriftDetector.Core;
-using AzureDriftDetector.Models;
+using DriftGuard.Core;
+using DriftGuard.Models;
 using System.CommandLine;
 
-namespace AzureDriftDetector;
+namespace DriftGuard;
 
 class Program
 {
     static async Task<int> Main(string[] args)
     {
-        var rootCommand = new RootCommand("Azure Configuration Drift Detector")
+        var rootCommand = new RootCommand("DriftGuard - Azure Configuration Drift Detector")
         {
-            Description = "Compares Bicep/ARM templates with live Azure resources to detect configuration drift"
+            Description = "Detects configuration drift between Bicep/ARM templates and live Azure resources"
         };
 
         // Bicep file option
@@ -92,7 +92,7 @@ class Program
                     return;
                 }
 
-                Console.WriteLine($"{(simpleOutput ? "[INFO]" : "🔍")} Azure Configuration Drift Detector v3.7.0");
+                Console.WriteLine($"{(simpleOutput ? "[INFO]" : "🔍")} DriftGuard v3.7.0");
                 Console.WriteLine($"{(simpleOutput ? "[FILE]" : "📄")} Bicep Template: {bicepFile.Name}");
                 Console.WriteLine($"{(simpleOutput ? "[RG]" : "🏗️")}  Resource Group: {resourceGroup}");
                 Console.WriteLine($"{(simpleOutput ? "[OUTPUT]" : "📊")} Output Format: {outputFormat}");

--- a/Program.cs
+++ b/Program.cs
@@ -8,7 +8,7 @@ class Program
 {
     static async Task<int> Main(string[] args)
     {
-        var rootCommand = new RootCommand("DriftGuard - Azure Configuration Drift Detector")
+        var rootCommand = new RootCommand("Azure DriftGuard - Configuration Drift Detector")
         {
             Description = "Detects configuration drift between Bicep/ARM templates and live Azure resources"
         };
@@ -92,7 +92,7 @@ class Program
                     return;
                 }
 
-                Console.WriteLine($"{(simpleOutput ? "[INFO]" : "🔍")} DriftGuard v3.7.0");
+                Console.WriteLine($"{(simpleOutput ? "[INFO]" : "🔍")} Azure DriftGuard v4.0.0");
                 Console.WriteLine($"{(simpleOutput ? "[FILE]" : "📄")} Bicep Template: {bicepFile.Name}");
                 Console.WriteLine($"{(simpleOutput ? "[RG]" : "🏗️")}  Resource Group: {resourceGroup}");
                 Console.WriteLine($"{(simpleOutput ? "[OUTPUT]" : "📊")} Output Format: {outputFormat}");

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Azure Configuration Drift Detector
+# DriftGuard
 
 A sophisticated C# console application that detects configuration drift between Bicep/ARM templates and live Azure resources. Built for DevOps teams practicing Infrastructure as Code (IaC) to ensure deployed resources match their intended configuration.
 
@@ -11,7 +11,7 @@ Configuration drift occurs when live Azure resources diverge from their Infrastr
 - Azure policy enforcement
 - Resource auto-scaling or auto-updates
 
-The Azure Configuration Drift Detector helps maintain **IaC compliance** by identifying these deviations quickly and clearly.
+DriftGuard helps maintain **IaC compliance** by identifying these deviations quickly and clearly.
 
 ## ✨ Key Features
 
@@ -73,7 +73,7 @@ The Azure Configuration Drift Detector helps maintain **IaC compliance** by iden
 ### Installation
 ```bash
 git clone <your-repo>
-cd AzureDriftDetector
+cd DriftGuard
 dotnet build
 ```
 
@@ -617,7 +617,7 @@ Options:
 ## 🏛️ Architecture
 
 ```
-AzureDriftDetector/
+DriftGuard/
 ├── Core/
 │   └── DriftDetector.cs          # Main orchestration logic with ignore integration
 ├── Models/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DriftGuard
+# Azure DriftGuard
 
 A sophisticated C# console application that detects configuration drift between Bicep/ARM templates and live Azure resources. Built for DevOps teams practicing Infrastructure as Code (IaC) to ensure deployed resources match their intended configuration.
 

--- a/Services/AzureCliService.cs
+++ b/Services/AzureCliService.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics;
 using System.Text.Json;
-using AzureDriftDetector.Models;
+using DriftGuard.Models;
 using Newtonsoft.Json.Linq;
 
-namespace AzureDriftDetector.Services;
+namespace DriftGuard.Services;
 
 public class AzureCliService
 {

--- a/Services/BicepService.cs
+++ b/Services/BicepService.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using Newtonsoft.Json.Linq;
 
-namespace AzureDriftDetector.Services;
+namespace DriftGuard.Services;
 
 public class BicepService
 {

--- a/Services/ComparisonService.cs
+++ b/Services/ComparisonService.cs
@@ -1,8 +1,8 @@
-using AzureDriftDetector.Models;
+using DriftGuard.Models;
 using Newtonsoft.Json.Linq;
 using JsonDiffPatchDotNet;
 
-namespace AzureDriftDetector.Services;
+namespace DriftGuard.Services;
 
 public class ComparisonService
 {

--- a/Services/DriftIgnoreService.cs
+++ b/Services/DriftIgnoreService.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using AzureDriftDetector.Models;
+using DriftGuard.Models;
 
-namespace AzureDriftDetector.Services;
+namespace DriftGuard.Services;
 
 public class DriftIgnoreService
 {

--- a/Services/ReportingService.cs
+++ b/Services/ReportingService.cs
@@ -1,8 +1,8 @@
-using AzureDriftDetector.Models;
+using DriftGuard.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace AzureDriftDetector.Services;
+namespace DriftGuard.Services;
 
 public class ReportingService
 {
@@ -31,7 +31,7 @@ public class ReportingService
         
         Console.WriteLine();
         Console.WriteLine(new string('=', 60));
-        Console.WriteLine($"{(simpleOutput ? "[DRIFT REPORT]" : "🔍")} AZURE CONFIGURATION DRIFT DETECTION REPORT");
+        Console.WriteLine($"{(simpleOutput ? "[DRIFT REPORT]" : "🔍")} DRIFTGUARD - CONFIGURATION DRIFT DETECTION REPORT");
         Console.WriteLine(new string('=', 60));
         Console.WriteLine($"{(simpleOutput ? "[TIME]" : "📅")} Detection Time: {result.DetectedAt:yyyy-MM-dd HH:mm:ss} UTC");
         Console.WriteLine($"{(simpleOutput ? "[SUMMARY]" : "📊")} Summary: {result.Summary}");
@@ -195,7 +195,7 @@ public class ReportingService
 </head>
 <body>
     <div class='header'>
-        <h1>{statusIcon} Azure Configuration Drift Detection Report</h1>
+        <h1>{statusIcon} DriftGuard - Configuration Drift Detection Report</h1>
         <p><strong>Detection Time:</strong> {result.DetectedAt:yyyy-MM-dd HH:mm:ss} UTC</p>
         <p><strong>Summary:</strong> <span class='{statusClass}'>{result.Summary}</span></p>
     </div>
@@ -241,7 +241,7 @@ public class ReportingService
         var statusIcon = result.HasDrift ? "❌" : "✅";
         
         var markdown = $"""
-        # {statusIcon} Azure Configuration Drift Detection Report
+        # {statusIcon} DriftGuard - Configuration Drift Detection Report
         
         **Detection Time:** {result.DetectedAt:yyyy-MM-dd HH:mm:ss} UTC  
         **Summary:** {result.Summary}

--- a/Services/ReportingService.cs
+++ b/Services/ReportingService.cs
@@ -31,7 +31,7 @@ public class ReportingService
         
         Console.WriteLine();
         Console.WriteLine(new string('=', 60));
-        Console.WriteLine($"{(simpleOutput ? "[DRIFT REPORT]" : "🔍")} DRIFTGUARD - CONFIGURATION DRIFT DETECTION REPORT");
+        Console.WriteLine($"{(simpleOutput ? "[DRIFT REPORT]" : "🔍")} AZURE DRIFTGUARD - CONFIGURATION DRIFT DETECTION REPORT");
         Console.WriteLine(new string('=', 60));
         Console.WriteLine($"{(simpleOutput ? "[TIME]" : "📅")} Detection Time: {result.DetectedAt:yyyy-MM-dd HH:mm:ss} UTC");
         Console.WriteLine($"{(simpleOutput ? "[SUMMARY]" : "📊")} Summary: {result.Summary}");
@@ -195,7 +195,7 @@ public class ReportingService
 </head>
 <body>
     <div class='header'>
-        <h1>{statusIcon} DriftGuard - Configuration Drift Detection Report</h1>
+        <h1>{statusIcon} Azure DriftGuard - Configuration Drift Detection Report</h1>
         <p><strong>Detection Time:</strong> {result.DetectedAt:yyyy-MM-dd HH:mm:ss} UTC</p>
         <p><strong>Summary:</strong> <span class='{statusClass}'>{result.Summary}</span></p>
     </div>
@@ -241,7 +241,7 @@ public class ReportingService
         var statusIcon = result.HasDrift ? "❌" : "✅";
         
         var markdown = $"""
-        # {statusIcon} DriftGuard - Configuration Drift Detection Report
+        # {statusIcon} Azure DriftGuard - Configuration Drift Detection Report
         
         **Detection Time:** {result.DetectedAt:yyyy-MM-dd HH:mm:ss} UTC  
         **Summary:** {result.Summary}

--- a/Services/WhatIfJsonService.cs
+++ b/Services/WhatIfJsonService.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics;
 using System.Text.Json;
-using AzureDriftDetector.Models;
+using DriftGuard.Models;
 
-namespace AzureDriftDetector.Services;
+namespace DriftGuard.Services;
 
 /// <summary>
 /// Service to parse what-if JSON output for drift detection.

--- a/docs/BICEP-BUILD.md
+++ b/docs/BICEP-BUILD.md
@@ -42,8 +42,8 @@ find . -name "*.bicep" -exec bicep build {} \;
 The generated JSON files are:
 - ✅ **Build artifacts** - generated from source Bicep files
 - ❌ **Not tracked in git** - excluded via .gitignore  
-- 🔄 **Generated as needed** - by the drift detector tool or manual build
+- 🔄 **Generated as needed** - by DriftGuard or manual build
 
 ## Automatic Building
 
-The Azure Drift Detector automatically compiles Bicep to ARM JSON as part of its process, so manual building is typically not required unless you want to inspect the generated ARM templates.
+DriftGuard automatically compiles Bicep to ARM JSON as part of its process, so manual building is typically not required unless you want to inspect the generated ARM templates.

--- a/docs/DRIFT-IGNORE.md
+++ b/docs/DRIFT-IGNORE.md
@@ -1,6 +1,6 @@
 # Drift Ignore Configuration
 
-The Azure Drift Detector includes a sophisticated ignore system to suppress false positive drift detections caused by Azure platform behaviors, managed properties, and other expected variations.
+DriftGuard includes a sophisticated ignore system to suppress false positive drift detections caused by Azure platform behaviors, managed properties, and other expected variations.
 
 ## Overview
 
@@ -256,7 +256,7 @@ Periodically review your ignore rules to ensure they're still relevant:
 
 ### Debug Ignore Rules
 
-The drift detector shows which ignores are being applied:
+DriftGuard shows which ignores are being applied:
 
 ```
 🔇 Ignoring drift: Microsoft.ServiceBus/namespaces/queues/myqueue - properties.autoDeleteOnIdle
@@ -308,7 +308,7 @@ Conditions use AND logic - all must match:
 
 ## File Location Priority
 
-The drift detector searches for ignore configuration in this order:
+DriftGuard searches for ignore configuration in this order:
 
 1. Path specified by `--ignore-config` parameter
 2. `drift-ignore.json` in current working directory

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,6 +1,6 @@
-# 🔍 Azure Configuration Drift Monitoring
+# 🔍 DriftGuard Monitoring
 
-This project includes automated Azure configuration drift monitoring using GitHub Actions.
+This project includes automated drift monitoring using GitHub Actions.
 
 ## 🚀 Quick Setup
 
@@ -47,7 +47,7 @@ gh workflow run drift-monitoring.yml
 ```
 
 ### Drift Detection Process
-1. **Download** latest drift detector binary
+1. **Download** latest DriftGuard binary
 2. **Login** to Azure using service principal
 3. **Compare** Bicep templates with live resources
 4. **Report** findings via GitHub issues
@@ -98,7 +98,7 @@ schedule:
 The monitoring uses `--simple-output` for better CI compatibility, but you can also generate HTML reports:
 
 ```bash
-./AzureDriftDetector --bicep-file template.bicep --resource-group myRG --output Html
+./DriftGuard --bicep-file template.bicep --resource-group myRG --output Html
 ```
 
 ## 🚨 Issue Management
@@ -139,7 +139,7 @@ The monitoring uses `--simple-output` for better CI compatibility, but you can a
 ### Debugging
 ```bash
 # Test locally with same settings
-./AzureDriftDetector --bicep-file template.bicep --resource-group myRG --simple-output
+./DriftGuard --bicep-file template.bicep --resource-group myRG --simple-output
 
 # Check Azure CLI access
 az account show
@@ -164,9 +164,9 @@ az resource list --resource-group myRG
 ### Custom Reporting
 ```bash
 # Generate multiple report formats
-./AzureDriftDetector --output Json --simple-output
-./AzureDriftDetector --output Html
-./AzureDriftDetector --output Markdown
+./DriftGuard --output Json --simple-output
+./DriftGuard --output Html
+./DriftGuard --output Markdown
 ```
 
 ### Conditional Monitoring

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-This directory contains comprehensive documentation for the Azure Configuration Drift Detector.
+This directory contains comprehensive documentation for DriftGuard.
 
 ## Available Documentation
 
@@ -19,10 +19,10 @@ This directory contains comprehensive documentation for the Azure Configuration 
 Configuration guide for GitHub Advanced Security features including CodeQL analysis and dependency scanning.
 
 ### [Bicep Module Development Guide](BICEP-BUILD.md)
-Documentation for developing and maintaining the modular Bicep templates used by the drift detector.
+Documentation for developing and maintaining the modular Bicep templates used by DriftGuard.
 
 ### [Release Notes](RELEASE-NOTES.md)
-Version history and changelog for the Azure Configuration Drift Detector.
+Version history and changelog for DriftGuard.
 
 ### [Monitoring Setup](MONITORING.md)
 Guide for setting up automated drift monitoring with GitHub Actions.

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,5 +1,43 @@
 # Release Notes
 
+## Version 4.0.0 - Azure DriftGuard Rebrand (2026-01-12)
+
+### 🎯 Summary
+Major release introducing the **Azure DriftGuard** rebrand to clearly identify this as an Azure-specific configuration drift detection tool.
+
+### ✨ Branding Changes
+
+#### 🌐 Azure DriftGuard Identity
+- **Product Renamed**: From "DriftGuard" to "Azure DriftGuard" throughout all user-facing surfaces
+- **CLI Banner**: Updated to "Azure DriftGuard v4.0.0"
+- **Console Reports**: Header now shows "AZURE DRIFTGUARD - CONFIGURATION DRIFT DETECTION REPORT"
+- **HTML Reports**: Title updated to "Azure DriftGuard - Configuration Drift Detection Report"
+- **Markdown Reports**: Header updated with Azure branding
+- **Assembly Metadata**: Product name in .csproj updated
+
+### 📝 Why the Change?
+This tool is purpose-built for Azure infrastructure drift detection using:
+- Azure CLI for resource queries
+- Azure What-If deployments for drift analysis
+- Bicep/ARM template comparison
+- Azure-specific ignore patterns
+
+The "Azure" prefix makes this clear to users and distinguishes it from generic drift detection tools.
+
+### 🔧 Technical Details
+- Updated `Program.cs` root command description and version banner
+- Updated `ReportingService.cs` for Console, HTML, and Markdown reports
+- Updated `DriftGuard.csproj` Product metadata
+- Updated `README.md` title and branding
+- Internal namespaces remain `DriftGuard` for code compatibility
+
+### 📦 Migration Notes
+- No breaking changes to CLI arguments or configuration files
+- All existing `drift-ignore.json` configurations remain compatible
+- Output format unchanged, only branding text updated
+
+---
+
 ## Version 3.7.0 - JSON-Based What-If Parsing & Audit Mode (2025-12-11)
 
 ### 🎯 Summary

--- a/docs/SECURITY-SETUP.md
+++ b/docs/SECURITY-SETUP.md
@@ -1,6 +1,6 @@
 # Security Setup Guide
 
-This guide explains how to enable GitHub's security features for the Azure Drift Detector project.
+This guide explains how to enable GitHub's security features for the DriftGuard project.
 
 ## 🛡️ GitHub Advanced Security for Private Repositories
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -45,6 +45,6 @@ The CI workflow currently skips test execution but maintains the infrastructure 
 ```
 
 ## Files to Restore When Fixed
-- `tests/AzureDriftDetector.Tests/AzureDriftDetector.Tests.csproj`
-- `tests/AzureDriftDetector.Tests/UnitTest1.cs` (DriftIgnoreServiceTests)
-- `tests/AzureDriftDetector.Tests/ComparisonServiceTests.cs`
+- `tests/DriftGuard.Tests/DriftGuard.Tests.csproj`
+- `tests/DriftGuard.Tests/UnitTest1.cs` (DriftIgnoreServiceTests)
+- `tests/DriftGuard.Tests/ComparisonServiceTests.cs`

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,6 +1,6 @@
 # 📋 Sample Bicep Templates
 
-This directory contains example Bicep templates and parameter files for testing and demonstrating the Azure Drift Detector tool.
+This directory contains example Bicep templates and parameter files for testing and demonstrating DriftGuard.
 
 ## 📁 Contents
 

--- a/samples/main-template.bicepparam
+++ b/samples/main-template.bicepparam
@@ -170,4 +170,4 @@ param deployStorage = true
 param deployAppServicePlan = true
 param deployLogAnalytics = true
 param deployKeyVault = false
-param deployServiceBus = true
+param deployServiceBus = false

--- a/samples/main-template.json
+++ b/samples/main-template.json
@@ -1,0 +1,1714 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.38.33.27573",
+      "templateHash": "17944688021458495524"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Common parameters"
+      }
+    },
+    "environmentName": {
+      "type": "string"
+    },
+    "applicationName": {
+      "type": "string"
+    },
+    "storageConfig": {
+      "type": "object",
+      "metadata": {
+        "description": "Storage account configuration"
+      }
+    },
+    "vnetConfig": {
+      "type": "object",
+      "metadata": {
+        "description": "Virtual network configuration"
+      }
+    },
+    "nsgConfig": {
+      "type": "object",
+      "metadata": {
+        "description": "Network security group configuration"
+      }
+    },
+    "appServicePlanConfig": {
+      "type": "object",
+      "metadata": {
+        "description": "App Service Plan configuration"
+      }
+    },
+    "logAnalyticsConfig": {
+      "type": "object",
+      "nullable": true,
+      "metadata": {
+        "description": "Log Analytics Workspace configuration"
+      }
+    },
+    "keyVaultConfig": {
+      "type": "object",
+      "nullable": true,
+      "metadata": {
+        "description": "Key Vault configuration"
+      }
+    },
+    "serviceBusConfig": {
+      "type": "object",
+      "nullable": true,
+      "metadata": {
+        "description": "Service Bus configuration"
+      }
+    },
+    "tags": {
+      "type": "object",
+      "metadata": {
+        "description": "Common resource tags"
+      }
+    },
+    "deployVnet": {
+      "type": "bool",
+      "metadata": {
+        "description": "Deployment switches"
+      }
+    },
+    "deployNsg": {
+      "type": "bool"
+    },
+    "deployStorage": {
+      "type": "bool"
+    },
+    "deployAppServicePlan": {
+      "type": "bool"
+    },
+    "deployLogAnalytics": {
+      "type": "bool"
+    },
+    "deployKeyVault": {
+      "type": "bool"
+    },
+    "deployServiceBus": {
+      "type": "bool"
+    }
+  },
+  "variables": {
+    "uniqueSuffix": "[take(uniqueString(resourceGroup().id), 8)]",
+    "vnetConfigWithCommon": "[union(parameters('vnetConfig'), createObject('location', parameters('location'), 'tags', parameters('tags')))]",
+    "nsgConfigWithCommon": "[union(parameters('nsgConfig'), createObject('location', parameters('location'), 'tags', parameters('tags')))]",
+    "storageConfigWithCommon": "[union(parameters('storageConfig'), createObject('location', parameters('location'), 'tags', parameters('tags'), 'storageAccountName', format('{0}{1}', parameters('storageConfig').storageAccountName, variables('uniqueSuffix'))))]",
+    "appServicePlanConfigWithCommon": "[union(parameters('appServicePlanConfig'), createObject('location', parameters('location'), 'tags', parameters('tags')))]",
+    "logAnalyticsConfigWithCommon": "[if(not(equals(parameters('logAnalyticsConfig'), null())), union(parameters('logAnalyticsConfig'), createObject('location', parameters('location'), 'tags', parameters('tags'), 'name', format('{0}-{1}', parameters('logAnalyticsConfig').name, variables('uniqueSuffix')))), null())]",
+    "keyVaultConfigWithCommon": "[if(not(equals(parameters('keyVaultConfig'), null())), union(parameters('keyVaultConfig'), createObject('location', parameters('location'), 'tags', parameters('tags'), 'name', format('{0}{1}', parameters('keyVaultConfig').name, variables('uniqueSuffix')))), null())]",
+    "serviceBusConfigWithCommon": "[if(not(equals(parameters('serviceBusConfig'), null())), union(parameters('serviceBusConfig'), createObject('location', parameters('location'), 'tags', parameters('tags'), 'name', parameters('serviceBusConfig').name)), null())]"
+  },
+  "resources": {
+    "vnetModule": {
+      "condition": "[parameters('deployVnet')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "vnet-deployment",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "vnetConfig": {
+            "value": "[variables('vnetConfigWithCommon')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.38.33.27573",
+              "templateHash": "1171659666513820870"
+            }
+          },
+          "definitions": {
+            "EnableState": {
+              "type": "string",
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "Subnet": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Name of the subnet"
+                  }
+                },
+                "addressPrefix": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Address prefix for the subnet"
+                  }
+                },
+                "privateEndpointNetworkPolicies": {
+                  "$ref": "#/definitions/EnableState",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Private endpoint network policies"
+                  }
+                },
+                "privateLinkServiceNetworkPolicies": {
+                  "$ref": "#/definitions/EnableState",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Private link service network policies"
+                  }
+                },
+                "networkSecurityGroupId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Network security group resource ID"
+                  }
+                },
+                "routeTableId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Route table resource ID"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "VnetConfig": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Virtual network name"
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Location for the virtual network"
+                  }
+                },
+                "addressSpaces": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Address space for the virtual network"
+                  }
+                },
+                "subnets": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Subnet"
+                  },
+                  "metadata": {
+                    "description": "Subnets configuration"
+                  }
+                },
+                "enableDdosProtection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Enable DDoS protection"
+                  }
+                },
+                "ddosProtectionPlanId": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "DDoS protection plan resource ID (required if enableDdosProtection is true)"
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Tags for the virtual network"
+                  }
+                },
+                "dnsServers": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "DNS servers for the virtual network"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            }
+          },
+          "parameters": {
+            "vnetConfig": {
+              "$ref": "#/definitions/VnetConfig",
+              "metadata": {
+                "description": "Virtual network configuration"
+              }
+            }
+          },
+          "resources": {
+            "virtualNetwork": {
+              "type": "Microsoft.Network/virtualNetworks",
+              "apiVersion": "2023-04-01",
+              "name": "[parameters('vnetConfig').name]",
+              "location": "[coalesce(tryGet(parameters('vnetConfig'), 'location'), resourceGroup().location)]",
+              "tags": "[coalesce(tryGet(parameters('vnetConfig'), 'tags'), createObject())]",
+              "properties": {
+                "copy": [
+                  {
+                    "name": "subnets",
+                    "count": "[length(parameters('vnetConfig').subnets)]",
+                    "input": {
+                      "name": "[parameters('vnetConfig').subnets[copyIndex('subnets')].name]",
+                      "properties": {
+                        "addressPrefix": "[parameters('vnetConfig').subnets[copyIndex('subnets')].addressPrefix]",
+                        "privateEndpointNetworkPolicies": "[coalesce(tryGet(parameters('vnetConfig').subnets[copyIndex('subnets')], 'privateEndpointNetworkPolicies'), 'Enabled')]",
+                        "privateLinkServiceNetworkPolicies": "[coalesce(tryGet(parameters('vnetConfig').subnets[copyIndex('subnets')], 'privateLinkServiceNetworkPolicies'), 'Enabled')]",
+                        "networkSecurityGroup": "[if(not(empty(coalesce(tryGet(parameters('vnetConfig').subnets[copyIndex('subnets')], 'networkSecurityGroupId'), ''))), createObject('id', tryGet(parameters('vnetConfig').subnets[copyIndex('subnets')], 'networkSecurityGroupId')), null())]",
+                        "routeTable": "[if(not(empty(coalesce(tryGet(parameters('vnetConfig').subnets[copyIndex('subnets')], 'routeTableId'), ''))), createObject('id', tryGet(parameters('vnetConfig').subnets[copyIndex('subnets')], 'routeTableId')), null())]"
+                      }
+                    }
+                  }
+                ],
+                "addressSpace": {
+                  "addressPrefixes": "[coalesce(tryGet(parameters('vnetConfig'), 'addressSpaces'), createArray('10.0.0.0/16'))]"
+                },
+                "dhcpOptions": "[if(not(empty(coalesce(tryGet(parameters('vnetConfig'), 'dnsServers'), createArray()))), createObject('dnsServers', tryGet(parameters('vnetConfig'), 'dnsServers')), null())]",
+                "enableDdosProtection": "[coalesce(tryGet(parameters('vnetConfig'), 'enableDdosProtection'), false())]",
+                "ddosProtectionPlan": "[if(and(coalesce(tryGet(parameters('vnetConfig'), 'enableDdosProtection'), false()), not(empty(coalesce(tryGet(parameters('vnetConfig'), 'ddosProtectionPlanId'), '')))), createObject('id', tryGet(parameters('vnetConfig'), 'ddosProtectionPlanId')), null())]"
+              }
+            }
+          },
+          "outputs": {
+            "vnetId": {
+              "type": "string",
+              "metadata": {
+                "description": "Virtual network resource ID"
+              },
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetConfig').name)]"
+            },
+            "vnetName": {
+              "type": "string",
+              "metadata": {
+                "description": "Virtual network name"
+              },
+              "value": "[parameters('vnetConfig').name]"
+            },
+            "addressSpaces": {
+              "type": "array",
+              "metadata": {
+                "description": "Virtual network address space"
+              },
+              "value": "[reference('virtualNetwork').addressSpace.addressPrefixes]"
+            },
+            "subnets": {
+              "type": "array",
+              "metadata": {
+                "description": "Subnet details"
+              },
+              "copy": {
+                "count": "[length(parameters('vnetConfig').subnets)]",
+                "input": {
+                  "name": "[reference('virtualNetwork').subnets[copyIndex()].name]",
+                  "id": "[reference('virtualNetwork').subnets[copyIndex()].id]",
+                  "addressPrefix": "[reference('virtualNetwork').subnets[copyIndex()].properties.addressPrefix]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "nsgModule": {
+      "condition": "[parameters('deployNsg')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "nsg-deployment",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "nsgConfig": {
+            "value": "[variables('nsgConfigWithCommon')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.38.33.27573",
+              "templateHash": "9819415396877216900"
+            }
+          },
+          "definitions": {
+            "AccessType": {
+              "type": "string",
+              "allowedValues": [
+                "Allow",
+                "Deny"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "TrafficDirection": {
+              "type": "string",
+              "allowedValues": [
+                "Inbound",
+                "Outbound"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "NetworkProtocol": {
+              "type": "string",
+              "allowedValues": [
+                "*",
+                "Icmp",
+                "Tcp",
+                "Udp"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "SecurityRule": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Name of the security rule"
+                  }
+                },
+                "priority": {
+                  "type": "int",
+                  "minValue": 100,
+                  "maxValue": 4096,
+                  "metadata": {
+                    "description": "Priority of the rule"
+                  }
+                },
+                "access": {
+                  "$ref": "#/definitions/AccessType",
+                  "metadata": {
+                    "description": "Access type"
+                  }
+                },
+                "direction": {
+                  "$ref": "#/definitions/TrafficDirection",
+                  "metadata": {
+                    "description": "Direction of traffic"
+                  }
+                },
+                "protocol": {
+                  "$ref": "#/definitions/NetworkProtocol",
+                  "metadata": {
+                    "description": "Protocol"
+                  }
+                },
+                "sourcePortRange": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Source port range"
+                  }
+                },
+                "destinationPortRange": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Destination port range"
+                  }
+                },
+                "sourceAddressPrefix": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Source address prefix"
+                  }
+                },
+                "destinationAddressPrefix": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Destination address prefix"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "NsgConfig": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Network Security Group name"
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Location for the NSG"
+                  }
+                },
+                "securityRules": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/SecurityRule"
+                  },
+                  "metadata": {
+                    "description": "Security rules configuration"
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Tags for the NSG"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            }
+          },
+          "parameters": {
+            "nsgConfig": {
+              "$ref": "#/definitions/NsgConfig",
+              "metadata": {
+                "description": "Network Security Group configuration"
+              }
+            }
+          },
+          "resources": {
+            "networkSecurityGroup": {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2023-04-01",
+              "name": "[parameters('nsgConfig').name]",
+              "location": "[coalesce(tryGet(parameters('nsgConfig'), 'location'), resourceGroup().location)]",
+              "properties": {
+                "copy": [
+                  {
+                    "name": "securityRules",
+                    "count": "[length(parameters('nsgConfig').securityRules)]",
+                    "input": {
+                      "name": "[parameters('nsgConfig').securityRules[copyIndex('securityRules')].name]",
+                      "properties": {
+                        "priority": "[parameters('nsgConfig').securityRules[copyIndex('securityRules')].priority]",
+                        "access": "[parameters('nsgConfig').securityRules[copyIndex('securityRules')].access]",
+                        "direction": "[parameters('nsgConfig').securityRules[copyIndex('securityRules')].direction]",
+                        "protocol": "[parameters('nsgConfig').securityRules[copyIndex('securityRules')].protocol]",
+                        "sourcePortRange": "[parameters('nsgConfig').securityRules[copyIndex('securityRules')].sourcePortRange]",
+                        "destinationPortRange": "[parameters('nsgConfig').securityRules[copyIndex('securityRules')].destinationPortRange]",
+                        "sourceAddressPrefix": "[parameters('nsgConfig').securityRules[copyIndex('securityRules')].sourceAddressPrefix]",
+                        "destinationAddressPrefix": "[parameters('nsgConfig').securityRules[copyIndex('securityRules')].destinationAddressPrefix]"
+                      }
+                    }
+                  }
+                ]
+              },
+              "tags": "[coalesce(tryGet(parameters('nsgConfig'), 'tags'), createObject())]"
+            }
+          },
+          "outputs": {
+            "nsgId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgConfig').name)]"
+            },
+            "nsgName": {
+              "type": "string",
+              "value": "[parameters('nsgConfig').name]"
+            }
+          }
+        }
+      }
+    },
+    "storageModule": {
+      "condition": "[parameters('deployStorage')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "storage-deployment",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "storageAccountConfig": {
+            "value": "[variables('storageConfigWithCommon')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.38.33.27573",
+              "templateHash": "10685890064811945112"
+            }
+          },
+          "definitions": {
+            "StorageAccountSku": {
+              "type": "string",
+              "allowedValues": [
+                "Premium_LRS",
+                "Premium_ZRS",
+                "Standard_GRS",
+                "Standard_LRS",
+                "Standard_RAGRS",
+                "Standard_ZRS"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "StorageAccountKind": {
+              "type": "string",
+              "allowedValues": [
+                "BlobStorage",
+                "BlockBlobStorage",
+                "FileStorage",
+                "Storage",
+                "StorageV2"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "AccessTier": {
+              "type": "string",
+              "allowedValues": [
+                "Cool",
+                "Hot"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "TlsVersion": {
+              "type": "string",
+              "allowedValues": [
+                "TLS1_0",
+                "TLS1_1",
+                "TLS1_2"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "NetworkAction": {
+              "type": "string",
+              "allowedValues": [
+                "Allow",
+                "Deny"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "EnableState": {
+              "type": "string",
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "StorageAccountConfig": {
+              "type": "object",
+              "properties": {
+                "storageAccountName": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Name of the storage account"
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Location for the storage account"
+                  }
+                },
+                "skuName": {
+                  "$ref": "#/definitions/StorageAccountSku",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Storage account SKU"
+                  }
+                },
+                "kind": {
+                  "$ref": "#/definitions/StorageAccountKind",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Storage account kind"
+                  }
+                },
+                "accessTier": {
+                  "$ref": "#/definitions/AccessTier",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Storage account access tier"
+                  }
+                },
+                "allowBlobPublicAccess": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Allow public access to blobs"
+                  }
+                },
+                "allowSharedKeyAccess": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Allow shared key access"
+                  }
+                },
+                "minimumTlsVersion": {
+                  "$ref": "#/definitions/TlsVersion",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Minimum TLS version"
+                  }
+                },
+                "supportsHttpsTrafficOnly": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Enable HTTPS traffic only"
+                  }
+                },
+                "networkAclsDefaultAction": {
+                  "$ref": "#/definitions/NetworkAction",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Network access configuration"
+                  }
+                },
+                "virtualNetworkRules": {
+                  "type": "array",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Virtual network rules"
+                  }
+                },
+                "ipRules": {
+                  "type": "array",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "IP rules for firewall"
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Tags for the storage account"
+                  }
+                },
+                "isHnsEnabled": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Enable hierarchical namespace (Data Lake Gen2)"
+                  }
+                },
+                "largeFileSharesState": {
+                  "$ref": "#/definitions/EnableState",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Large file shares state"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            }
+          },
+          "parameters": {
+            "storageAccountConfig": {
+              "$ref": "#/definitions/StorageAccountConfig",
+              "metadata": {
+                "description": "Storage account configuration"
+              }
+            }
+          },
+          "resources": {
+            "storageAccount": {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2023-05-01",
+              "name": "[parameters('storageAccountConfig').storageAccountName]",
+              "location": "[coalesce(tryGet(parameters('storageAccountConfig'), 'location'), resourceGroup().location)]",
+              "kind": "[coalesce(tryGet(parameters('storageAccountConfig'), 'kind'), 'StorageV2')]",
+              "sku": {
+                "name": "[coalesce(tryGet(parameters('storageAccountConfig'), 'skuName'), 'Standard_LRS')]"
+              },
+              "tags": "[coalesce(tryGet(parameters('storageAccountConfig'), 'tags'), createObject())]",
+              "properties": {
+                "accessTier": "[coalesce(tryGet(parameters('storageAccountConfig'), 'accessTier'), 'Hot')]",
+                "allowBlobPublicAccess": "[coalesce(tryGet(parameters('storageAccountConfig'), 'allowBlobPublicAccess'), false())]",
+                "allowSharedKeyAccess": "[coalesce(tryGet(parameters('storageAccountConfig'), 'allowSharedKeyAccess'), true())]",
+                "minimumTlsVersion": "[coalesce(tryGet(parameters('storageAccountConfig'), 'minimumTlsVersion'), 'TLS1_2')]",
+                "supportsHttpsTrafficOnly": "[coalesce(tryGet(parameters('storageAccountConfig'), 'supportsHttpsTrafficOnly'), true())]",
+                "isHnsEnabled": "[coalesce(tryGet(parameters('storageAccountConfig'), 'isHnsEnabled'), false())]",
+                "largeFileSharesState": "[coalesce(tryGet(parameters('storageAccountConfig'), 'largeFileSharesState'), 'Disabled')]",
+                "networkAcls": {
+                  "defaultAction": "[coalesce(tryGet(parameters('storageAccountConfig'), 'networkAclsDefaultAction'), 'Allow')]",
+                  "virtualNetworkRules": "[coalesce(tryGet(parameters('storageAccountConfig'), 'virtualNetworkRules'), createArray())]",
+                  "ipRules": "[coalesce(tryGet(parameters('storageAccountConfig'), 'ipRules'), createArray())]",
+                  "bypass": "AzureServices"
+                }
+              }
+            }
+          },
+          "outputs": {
+            "storageAccountId": {
+              "type": "string",
+              "metadata": {
+                "description": "Storage account resource ID"
+              },
+              "value": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountConfig').storageAccountName)]"
+            },
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Storage account name"
+              },
+              "value": "[parameters('storageAccountConfig').storageAccountName]"
+            },
+            "primaryBlobEndpoint": {
+              "type": "string",
+              "metadata": {
+                "description": "Storage account primary blob endpoint"
+              },
+              "value": "[reference('storageAccount').primaryEndpoints.blob]"
+            }
+          }
+        }
+      }
+    },
+    "appServicePlanModule": {
+      "condition": "[parameters('deployAppServicePlan')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "app-service-plan-deployment",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "appServicePlanConfig": {
+            "value": "[variables('appServicePlanConfigWithCommon')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.38.33.27573",
+              "templateHash": "15347448570641430300"
+            }
+          },
+          "definitions": {
+            "AppServicePlanSku": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "SKU name (e.g., F1, B1, S1, P1v2)"
+                  }
+                },
+                "tier": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "SKU tier (e.g., Free, Basic, Standard, Premium)"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "AppServicePlanConfig": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "App Service Plan name"
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Location for the App Service Plan"
+                  }
+                },
+                "sku": {
+                  "$ref": "#/definitions/AppServicePlanSku",
+                  "metadata": {
+                    "description": "SKU configuration for the App Service Plan"
+                  }
+                },
+                "reserved": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Whether the App Service Plan is reserved (Linux)"
+                  }
+                },
+                "zoneRedundant": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Enable zone redundancy"
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Tags for the App Service Plan"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            }
+          },
+          "parameters": {
+            "appServicePlanConfig": {
+              "$ref": "#/definitions/AppServicePlanConfig",
+              "metadata": {
+                "description": "App Service Plan configuration"
+              }
+            }
+          },
+          "resources": {
+            "appServicePlan": {
+              "type": "Microsoft.Web/serverfarms",
+              "apiVersion": "2023-01-01",
+              "name": "[parameters('appServicePlanConfig').name]",
+              "location": "[coalesce(tryGet(parameters('appServicePlanConfig'), 'location'), resourceGroup().location)]",
+              "sku": "[parameters('appServicePlanConfig').sku]",
+              "properties": {
+                "reserved": "[coalesce(tryGet(parameters('appServicePlanConfig'), 'reserved'), false())]",
+                "zoneRedundant": "[coalesce(tryGet(parameters('appServicePlanConfig'), 'zoneRedundant'), false())]"
+              },
+              "tags": "[coalesce(tryGet(parameters('appServicePlanConfig'), 'tags'), createObject())]"
+            }
+          },
+          "outputs": {
+            "appServicePlanId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanConfig').name)]"
+            },
+            "appServicePlanName": {
+              "type": "string",
+              "value": "[parameters('appServicePlanConfig').name]"
+            }
+          }
+        }
+      }
+    },
+    "logAnalyticsModule": {
+      "condition": "[and(parameters('deployLogAnalytics'), not(equals(parameters('logAnalyticsConfig'), null())))]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "log-analytics-deployment",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "logAnalyticsConfig": {
+            "value": "[variables('logAnalyticsConfigWithCommon')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.38.33.27573",
+              "templateHash": "9638491463814574907"
+            }
+          },
+          "definitions": {
+            "LogAnalyticsSku": {
+              "type": "string",
+              "allowedValues": [
+                "Free",
+                "PerGB2018",
+                "PerNode",
+                "Premium",
+                "Standalone",
+                "Standard"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "LogAnalyticsConfig": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Log Analytics Workspace name"
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Location for the workspace"
+                  }
+                },
+                "skuName": {
+                  "$ref": "#/definitions/LogAnalyticsSku",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "SKU name"
+                  }
+                },
+                "retentionInDays": {
+                  "type": "int",
+                  "nullable": true,
+                  "minValue": 30,
+                  "maxValue": 730,
+                  "metadata": {
+                    "description": "Data retention in days"
+                  }
+                },
+                "enableLogAccessUsingOnlyResourcePermissions": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Enable log access using only resource permissions"
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Tags for the workspace"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            }
+          },
+          "parameters": {
+            "logAnalyticsConfig": {
+              "$ref": "#/definitions/LogAnalyticsConfig",
+              "metadata": {
+                "description": "Log Analytics Workspace configuration"
+              }
+            }
+          },
+          "resources": {
+            "logAnalyticsWorkspace": {
+              "type": "Microsoft.OperationalInsights/workspaces",
+              "apiVersion": "2023-09-01",
+              "name": "[parameters('logAnalyticsConfig').name]",
+              "location": "[coalesce(tryGet(parameters('logAnalyticsConfig'), 'location'), resourceGroup().location)]",
+              "properties": {
+                "sku": {
+                  "name": "[coalesce(tryGet(parameters('logAnalyticsConfig'), 'skuName'), 'PerGB2018')]"
+                },
+                "retentionInDays": "[coalesce(tryGet(parameters('logAnalyticsConfig'), 'retentionInDays'), 30)]",
+                "features": {
+                  "enableLogAccessUsingOnlyResourcePermissions": "[coalesce(tryGet(parameters('logAnalyticsConfig'), 'enableLogAccessUsingOnlyResourcePermissions'), true())]"
+                }
+              },
+              "tags": "[coalesce(tryGet(parameters('logAnalyticsConfig'), 'tags'), createObject())]"
+            }
+          },
+          "outputs": {
+            "workspaceId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsConfig').name)]"
+            },
+            "workspaceName": {
+              "type": "string",
+              "value": "[parameters('logAnalyticsConfig').name]"
+            },
+            "customerId": {
+              "type": "string",
+              "value": "[reference('logAnalyticsWorkspace').customerId]"
+            }
+          }
+        }
+      }
+    },
+    "keyVaultModule": {
+      "condition": "[and(parameters('deployKeyVault'), not(equals(parameters('keyVaultConfig'), null())))]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "key-vault-deployment",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "keyVaultConfig": {
+            "value": "[variables('keyVaultConfigWithCommon')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.38.33.27573",
+              "templateHash": "6985757085383599710"
+            }
+          },
+          "definitions": {
+            "KeyVaultSkuFamily": {
+              "type": "string",
+              "allowedValues": [
+                "A"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "KeyVaultSkuName": {
+              "type": "string",
+              "allowedValues": [
+                "premium",
+                "standard"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "PublicAccess": {
+              "type": "string",
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "KeyVaultSku": {
+              "type": "object",
+              "properties": {
+                "family": {
+                  "$ref": "#/definitions/KeyVaultSkuFamily",
+                  "metadata": {
+                    "description": "SKU family"
+                  }
+                },
+                "name": {
+                  "$ref": "#/definitions/KeyVaultSkuName",
+                  "metadata": {
+                    "description": "SKU name"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "KeyVaultConfig": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Key Vault name"
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Location for the Key Vault"
+                  }
+                },
+                "sku": {
+                  "$ref": "#/definitions/KeyVaultSku",
+                  "metadata": {
+                    "description": "SKU configuration"
+                  }
+                },
+                "enabledForDeployment": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Enable for deployment"
+                  }
+                },
+                "enabledForTemplateDeployment": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Enable for template deployment"
+                  }
+                },
+                "enabledForDiskEncryption": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Enable for disk encryption"
+                  }
+                },
+                "enableRbacAuthorization": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Enable RBAC authorization"
+                  }
+                },
+                "publicNetworkAccess": {
+                  "$ref": "#/definitions/PublicAccess",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Public network access"
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Tags for the Key Vault"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            }
+          },
+          "parameters": {
+            "keyVaultConfig": {
+              "$ref": "#/definitions/KeyVaultConfig",
+              "metadata": {
+                "description": "Key Vault configuration"
+              }
+            }
+          },
+          "resources": {
+            "keyVault": {
+              "type": "Microsoft.KeyVault/vaults",
+              "apiVersion": "2023-07-01",
+              "name": "[parameters('keyVaultConfig').name]",
+              "location": "[coalesce(tryGet(parameters('keyVaultConfig'), 'location'), resourceGroup().location)]",
+              "properties": {
+                "sku": "[parameters('keyVaultConfig').sku]",
+                "tenantId": "[subscription().tenantId]",
+                "enabledForDeployment": "[coalesce(tryGet(parameters('keyVaultConfig'), 'enabledForDeployment'), false())]",
+                "enabledForTemplateDeployment": "[coalesce(tryGet(parameters('keyVaultConfig'), 'enabledForTemplateDeployment'), false())]",
+                "enabledForDiskEncryption": "[coalesce(tryGet(parameters('keyVaultConfig'), 'enabledForDiskEncryption'), false())]",
+                "enableRbacAuthorization": "[coalesce(tryGet(parameters('keyVaultConfig'), 'enableRbacAuthorization'), true())]",
+                "publicNetworkAccess": "[coalesce(tryGet(parameters('keyVaultConfig'), 'publicNetworkAccess'), 'Enabled')]"
+              },
+              "tags": "[coalesce(tryGet(parameters('keyVaultConfig'), 'tags'), createObject())]"
+            }
+          },
+          "outputs": {
+            "keyVaultId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultConfig').name)]"
+            },
+            "keyVaultName": {
+              "type": "string",
+              "value": "[parameters('keyVaultConfig').name]"
+            },
+            "keyVaultUri": {
+              "type": "string",
+              "value": "[reference('keyVault').vaultUri]"
+            }
+          }
+        }
+      }
+    },
+    "serviceBusModule": {
+      "condition": "[and(parameters('deployServiceBus'), not(equals(parameters('serviceBusConfig'), null())))]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "service-bus-deployment",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "serviceBusConfig": {
+            "value": "[variables('serviceBusConfigWithCommon')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.38.33.27573",
+              "templateHash": "14951496741211156382"
+            }
+          },
+          "definitions": {
+            "ServiceBusSku": {
+              "type": "string",
+              "allowedValues": [
+                "Basic",
+                "Premium",
+                "Standard"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "TlsVersion": {
+              "type": "string",
+              "allowedValues": [
+                "1.0",
+                "1.1",
+                "1.2"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "PublicNetworkAccess": {
+              "type": "string",
+              "allowedValues": [
+                "Disabled",
+                "Enabled"
+              ],
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "QueueConfig": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Queue name"
+                  }
+                },
+                "maxDeliveryCount": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Maximum delivery count"
+                  }
+                },
+                "lockDuration": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Lock duration (ISO 8601 duration format)"
+                  }
+                },
+                "requiresDuplicateDetection": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Requires duplicate detection"
+                  }
+                },
+                "requiresSession": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Requires session"
+                  }
+                },
+                "deadLetteringOnMessageExpiration": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Dead lettering on message expiration"
+                  }
+                },
+                "autoDeleteOnIdle": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Auto delete on idle (ISO 8601 duration format)"
+                  }
+                },
+                "defaultMessageTimeToLive": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Default message time to live (ISO 8601 duration format)"
+                  }
+                },
+                "duplicateDetectionHistoryTimeWindow": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Duplicate detection history time window (ISO 8601 duration format)"
+                  }
+                },
+                "maxMessageSizeInKilobytes": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Maximum message size in kilobytes"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "SubscriptionConfig": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Subscription name"
+                  }
+                },
+                "maxDeliveryCount": {
+                  "type": "int",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Maximum delivery count"
+                  }
+                },
+                "lockDuration": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Lock duration (ISO 8601 duration format)"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "TopicConfig": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Topic name"
+                  }
+                },
+                "subscriptions": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/SubscriptionConfig"
+                  },
+                  "metadata": {
+                    "description": "Topic subscriptions"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            },
+            "ServiceBusConfig": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "metadata": {
+                    "description": "Service Bus namespace name"
+                  }
+                },
+                "location": {
+                  "type": "string",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Location for the Service Bus namespace"
+                  }
+                },
+                "skuName": {
+                  "$ref": "#/definitions/ServiceBusSku",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Service Bus SKU"
+                  }
+                },
+                "disableLocalAuth": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Disable local authentication"
+                  }
+                },
+                "publicNetworkAccess": {
+                  "$ref": "#/definitions/PublicNetworkAccess",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Public network access"
+                  }
+                },
+                "minimumTlsVersion": {
+                  "$ref": "#/definitions/TlsVersion",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Minimum TLS version"
+                  }
+                },
+                "queues": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/QueueConfig"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Queues configuration"
+                  }
+                },
+                "topics": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/TopicConfig"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Topics configuration"
+                  }
+                },
+                "tags": {
+                  "type": "object",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Tags for the Service Bus namespace"
+                  }
+                }
+              },
+              "metadata": {
+                "__bicep_export!": true
+              }
+            }
+          },
+          "parameters": {
+            "serviceBusConfig": {
+              "$ref": "#/definitions/ServiceBusConfig",
+              "metadata": {
+                "description": "Service Bus configuration"
+              }
+            }
+          },
+          "resources": {
+            "serviceBusNamespace": {
+              "type": "Microsoft.ServiceBus/namespaces",
+              "apiVersion": "2022-10-01-preview",
+              "name": "[parameters('serviceBusConfig').name]",
+              "location": "[coalesce(tryGet(parameters('serviceBusConfig'), 'location'), resourceGroup().location)]",
+              "tags": "[coalesce(tryGet(parameters('serviceBusConfig'), 'tags'), createObject())]",
+              "sku": {
+                "name": "[coalesce(tryGet(parameters('serviceBusConfig'), 'skuName'), 'Basic')]",
+                "tier": "[coalesce(tryGet(parameters('serviceBusConfig'), 'skuName'), 'Basic')]"
+              },
+              "properties": {
+                "disableLocalAuth": "[coalesce(tryGet(parameters('serviceBusConfig'), 'disableLocalAuth'), false())]",
+                "publicNetworkAccess": "[coalesce(tryGet(parameters('serviceBusConfig'), 'publicNetworkAccess'), 'Enabled')]",
+                "minimumTlsVersion": "[coalesce(tryGet(parameters('serviceBusConfig'), 'minimumTlsVersion'), '1.2')]",
+                "zoneRedundant": false
+              }
+            },
+            "queues": {
+              "copy": {
+                "name": "queues",
+                "count": "[length(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray()))]"
+              },
+              "type": "Microsoft.ServiceBus/namespaces/queues",
+              "apiVersion": "2022-10-01-preview",
+              "name": "[format('{0}/{1}', parameters('serviceBusConfig').name, coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()].name)]",
+              "properties": "[union(createObject('maxDeliveryCount', coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()], 'maxDeliveryCount'), 10), 'lockDuration', coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()], 'lockDuration'), 'PT1M'), 'requiresDuplicateDetection', coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()], 'requiresDuplicateDetection'), false()), 'requiresSession', coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()], 'requiresSession'), false()), 'deadLetteringOnMessageExpiration', coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()], 'deadLetteringOnMessageExpiration'), false()), 'maxSizeInMegabytes', 1024, 'enableBatchedOperations', true(), 'enablePartitioning', false()), if(not(equals(coalesce(tryGet(parameters('serviceBusConfig'), 'skuName'), 'Basic'), 'Basic')), createObject('autoDeleteOnIdle', coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()], 'autoDeleteOnIdle'), 'P10675199DT2H48M5.4775807S'), 'defaultMessageTimeToLive', coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()], 'defaultMessageTimeToLive'), 'P14D'), 'duplicateDetectionHistoryTimeWindow', coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()], 'duplicateDetectionHistoryTimeWindow'), 'PT10M'), 'maxMessageSizeInKilobytes', coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()], 'maxMessageSizeInKilobytes'), 256)), createObject()))]",
+              "dependsOn": [
+                "serviceBusNamespace"
+              ]
+            },
+            "topics": {
+              "copy": {
+                "name": "topics",
+                "count": "[length(coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray()))]"
+              },
+              "type": "Microsoft.ServiceBus/namespaces/topics",
+              "apiVersion": "2022-10-01-preview",
+              "name": "[format('{0}/{1}', parameters('serviceBusConfig').name, coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray())[copyIndex()].name)]",
+              "properties": {
+                "maxSizeInMegabytes": 1024,
+                "enableBatchedOperations": true,
+                "enablePartitioning": false
+              },
+              "dependsOn": [
+                "serviceBusNamespace"
+              ]
+            },
+            "topicSubscriptions": {
+              "copy": {
+                "name": "topicSubscriptions",
+                "count": "[length(coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray()))]"
+              },
+              "condition": "[greater(length(coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray())[copyIndex()], 'subscriptions'), createArray())), 0)]",
+              "type": "Microsoft.ServiceBus/namespaces/topics/subscriptions",
+              "apiVersion": "2022-10-01-preview",
+              "name": "[format('{0}/{1}/{2}', parameters('serviceBusConfig').name, coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray())[copyIndex()].name, coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray())[copyIndex()].subscriptions[0].name)]",
+              "properties": {
+                "maxDeliveryCount": "[coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray())[copyIndex()].subscriptions[0], 'maxDeliveryCount'), 10)]",
+                "lockDuration": "[coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray())[copyIndex()].subscriptions[0], 'lockDuration'), 'PT1M')]",
+                "deadLetteringOnMessageExpiration": "[coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray())[copyIndex()].subscriptions[0], 'deadLetteringOnMessageExpiration'), true())]",
+                "enableBatchedOperations": "[coalesce(tryGet(coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray())[copyIndex()].subscriptions[0], 'enableBatchedOperations'), true())]"
+              },
+              "dependsOn": [
+                "[format('topics[{0}]', copyIndex())]"
+              ]
+            }
+          },
+          "outputs": {
+            "serviceBusNamespaceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Service Bus namespace resource ID"
+              },
+              "value": "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusConfig').name)]"
+            },
+            "serviceBusNamespaceName": {
+              "type": "string",
+              "metadata": {
+                "description": "Service Bus namespace name"
+              },
+              "value": "[parameters('serviceBusConfig').name]"
+            },
+            "serviceBusEndpoint": {
+              "type": "string",
+              "metadata": {
+                "description": "Service Bus endpoint"
+              },
+              "value": "[reference('serviceBusNamespace').serviceBusEndpoint]"
+            },
+            "queueNames": {
+              "type": "array",
+              "metadata": {
+                "description": "Queue names"
+              },
+              "copy": {
+                "count": "[length(coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray()))]",
+                "input": "[coalesce(tryGet(parameters('serviceBusConfig'), 'queues'), createArray())[copyIndex()].name]"
+              }
+            },
+            "topicNames": {
+              "type": "array",
+              "metadata": {
+                "description": "Topic names"
+              },
+              "copy": {
+                "count": "[length(coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray()))]",
+                "input": "[coalesce(tryGet(parameters('serviceBusConfig'), 'topics'), createArray())[copyIndex()].name]"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "outputs": {
+    "vnetId": {
+      "type": "string",
+      "value": "[if(parameters('deployVnet'), reference('vnetModule').outputs.vnetId.value, '')]"
+    },
+    "storageAccountName": {
+      "type": "string",
+      "value": "[if(parameters('deployStorage'), reference('storageModule').outputs.storageAccountName.value, '')]"
+    },
+    "appServicePlanId": {
+      "type": "string",
+      "value": "[if(parameters('deployAppServicePlan'), reference('appServicePlanModule').outputs.appServicePlanId.value, '')]"
+    },
+    "logAnalyticsWorkspaceId": {
+      "type": "string",
+      "value": "[if(and(parameters('deployLogAnalytics'), not(equals(parameters('logAnalyticsConfig'), null()))), reference('logAnalyticsModule').outputs.workspaceId.value, '')]"
+    },
+    "keyVaultName": {
+      "type": "string",
+      "value": "[if(and(parameters('deployKeyVault'), not(equals(parameters('keyVaultConfig'), null()))), reference('keyVaultModule').outputs.keyVaultName.value, '')]"
+    },
+    "serviceBusNamespaceName": {
+      "type": "string",
+      "value": "[if(and(parameters('deployServiceBus'), not(equals(parameters('serviceBusConfig'), null()))), reference('serviceBusModule').outputs.serviceBusNamespaceName.value, '')]"
+    },
+    "nsgId": {
+      "type": "string",
+      "value": "[if(parameters('deployNsg'), reference('nsgModule').outputs.nsgId.value, '')]"
+    },
+    "environmentName": {
+      "type": "string",
+      "value": "[parameters('environmentName')]"
+    },
+    "applicationName": {
+      "type": "string",
+      "value": "[parameters('applicationName')]"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Major release introducing the **Azure DriftGuard** rebrand to clearly identify this as an Azure-specific configuration drift detection tool.

## Changes

### Branding Updates
- **Product Renamed**: From 'DriftGuard' to 'Azure DriftGuard' throughout all user-facing surfaces
- **CLI Banner**: Updated to 'Azure DriftGuard v4.0.0'
- **Console Reports**: Header shows 'AZURE DRIFTGUARD - CONFIGURATION DRIFT DETECTION REPORT'
- **HTML/Markdown Reports**: Titles updated with Azure branding
- **Assembly Metadata**: Product name in .csproj updated

### Version Bump
- Bumped to v4.0.0 (major release for rebrand)
- Added comprehensive release notes in docs/RELEASE-NOTES.md

### Why the Change?
This tool is purpose-built for Azure infrastructure drift detection using:
- Azure CLI for resource queries
- Azure What-If deployments for drift analysis  
- Bicep/ARM template comparison
- Azure-specific ignore patterns

The 'Azure' prefix makes this clear to users and distinguishes it from generic drift detection tools.

## Testing
- [x] Build succeeds
- [x] Deployed test resources to Azure
- [x] Verified drift detection works
- [x] Verified autofix remediation works
- [x] Cleaned up test resources

## Migration Notes
- No breaking changes to CLI arguments or configuration files
- All existing drift-ignore.json configurations remain compatible
- Internal namespaces remain 'DriftGuard' for code compatibility