### PR TITLE
fix: add ProduceReferenceAssembly to fix macOS build

### DIFF
--- a/BicepGuard.csproj
+++ b/BicepGuard.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <Product>Azure BicepGuard</Product>
     <Description>Detects configuration drift between Bicep templates and live Azure resources</Description>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

After the Dependabot bump of `Microsoft.NET.Test.Sdk` from `18.0.1` to `18.4.0`, the macOS CI job failed with:

```
CSC : error CS0009: Metadata file 'obj/Release/net8.0/ref/BicepGuard.dll' could not be opened -- PE image doesn't contain managed metadata.
```

## Root Cause

`Microsoft.NET.Test.Sdk` 18.4.0 changed how it interacts with ref assembly generation on macOS, resulting in a corrupt ref DLL for `Exe` projects.

## Fix

Explicitly set `<ProduceReferenceAssembly>true</ProduceReferenceAssembly>` in `BicepGuard.csproj` to ensure a valid managed ref assembly is always generated.