### PR TITLE
chore: consolidate dependabot updates and pin actions to SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
     
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
     - name: ⚙️ Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
@@ -47,7 +47,7 @@ jobs:
       run: dotnet test tests/BicepGuard.Tests/BicepGuard.Tests.csproj --no-build --configuration Release --logger "trx;LogFileName=test-results.trx" --verbosity normal
       
     - name: 📊 Upload test results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()
       with:
         name: test-results
@@ -71,10 +71,10 @@ jobs:
         
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
     - name: ⚙️ Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
@@ -98,10 +98,10 @@ jobs:
     
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
     - name: ⚙️ Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
@@ -111,7 +111,7 @@ jobs:
         dotnet list BicepGuard.csproj package --deprecated || true
         
     - name: 🛡️ Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         languages: csharp
       continue-on-error: true
@@ -123,7 +123,7 @@ jobs:
       run: dotnet build BicepGuard.csproj --configuration Release --no-restore
       
     - name: 🔍 Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         category: "/language:csharp"
       continue-on-error: true
@@ -134,7 +134,7 @@ jobs:
     
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
     - name: ⚙️ Setup Azure CLI
       run: |
@@ -166,10 +166,10 @@ jobs:
     
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       
     - name: ⚙️ Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         
@@ -197,7 +197,7 @@ jobs:
         echo ".NET Version: ${{ env.DOTNET_VERSION }}" >> ./artifacts/BUILD_INFO.txt
         
     - name: 📤 Upload artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: release-artifacts
         path: ./artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       run: dotnet test tests/BicepGuard.Tests/BicepGuard.Tests.csproj --no-build --configuration Release --logger "trx;LogFileName=test-results.trx" --verbosity normal
       
     - name: 📊 Upload test results
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: test-results
@@ -197,7 +197,7 @@ jobs:
         echo ".NET Version: ${{ env.DOTNET_VERSION }}" >> ./artifacts/BUILD_INFO.txt
         
     - name: 📤 Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: release-artifacts
         path: ./artifacts/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
     - name: 📥 Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: ⚙️ Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
         dotnet-version: '8.0.x'
 
     - name: 🛡️ Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         languages: ${{ matrix.language }}
         # Override default queries with security-focused ones
@@ -46,7 +46,7 @@ jobs:
       run: dotnet build BicepGuard.csproj --configuration Release --no-restore
 
     - name: 🔍 Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         category: "/language:${{matrix.language}}"
 

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -43,7 +43,7 @@ jobs:
         echo "Version: $VERSION"
         
     - name: 🔑 Login to Docker Hub
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       with:
         username: ${{ env.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -43,7 +43,7 @@ jobs:
         echo "Version: $VERSION"
         
     - name: 🔑 Login to Docker Hub
-      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+      uses: docker/login-action@v4
       with:
         username: ${{ env.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/drift-detection-reusable.yml
+++ b/.github/workflows/drift-detection-reusable.yml
@@ -119,7 +119,7 @@ jobs:
         bicep --version
 
     - name: 🔐 Azure Login (OIDC)
-      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+      uses: azure/login@v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -209,7 +209,7 @@ jobs:
 
     - name: 📊 Upload Drift Report
       if: always()
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+      uses: actions/upload-artifact@v7
       with:
         name: drift-report-${{ inputs.environment-name }}
         path: drift-report.json
@@ -217,7 +217,7 @@ jobs:
 
     - name: 🐛 Create Issue on Drift
       if: steps.drift.outputs.drift_detected == 'true' && inputs.create-issue == true
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      uses: actions/github-script@v9
       env:
         INPUT_SCOPE: ${{ inputs.scope }}
         INPUT_LOCATION: ${{ inputs.location }}
@@ -293,7 +293,7 @@ jobs:
 
     - name: ✅ Close Issue if No Drift
       if: steps.drift.outputs.drift_detected == 'false' && inputs.create-issue == true
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      uses: actions/github-script@v9
       env:
         INPUT_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
       with:

--- a/.github/workflows/drift-detection-reusable.yml
+++ b/.github/workflows/drift-detection-reusable.yml
@@ -119,7 +119,7 @@ jobs:
         bicep --version
 
     - name: 🔐 Azure Login (OIDC)
-      uses: azure/login@v3
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -209,7 +209,7 @@ jobs:
 
     - name: 📊 Upload Drift Report
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: drift-report-${{ inputs.environment-name }}
         path: drift-report.json
@@ -217,7 +217,7 @@ jobs:
 
     - name: 🐛 Create Issue on Drift
       if: steps.drift.outputs.drift_detected == 'true' && inputs.create-issue == true
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       env:
         INPUT_SCOPE: ${{ inputs.scope }}
         INPUT_LOCATION: ${{ inputs.location }}
@@ -293,7 +293,7 @@ jobs:
 
     - name: ✅ Close Issue if No Drift
       if: steps.drift.outputs.drift_detected == 'false' && inputs.create-issue == true
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       env:
         INPUT_ENVIRONMENT_NAME: ${{ inputs.environment-name }}
       with:

--- a/.github/workflows/drift-monitoring.yml
+++ b/.github/workflows/drift-monitoring.yml
@@ -50,7 +50,7 @@ jobs:
         sudo mv ./bicep /usr/local/bin/bicep
       
     - name: Azure Login
-      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
+      uses: azure/login@v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -68,14 +68,14 @@ jobs:
     
     - name: Upload Drift Report
       if: always()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: drift-report-${{ matrix.environment.name }}
         path: drift-report.json
 
     - name: Create Issue on Drift
       if: steps.check.outputs.drift == 'true'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         script: |
           const { createDriftIssue } = require('./.github/scripts/create-drift-issue.js');

--- a/.github/workflows/drift-monitoring.yml
+++ b/.github/workflows/drift-monitoring.yml
@@ -36,10 +36,10 @@ jobs:
     name: Monitor ${{ matrix.environment.name }}
     
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
     
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
         dotnet-version: '8.0.x'
     
@@ -50,7 +50,7 @@ jobs:
         sudo mv ./bicep /usr/local/bin/bicep
       
     - name: Azure Login
-      uses: azure/login@v3
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -68,14 +68,14 @@ jobs:
     
     - name: Upload Drift Report
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: drift-report-${{ matrix.environment.name }}
         path: drift-report.json
 
     - name: Create Issue on Drift
       if: steps.check.outputs.drift == 'true'
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
           const { createDriftIssue } = require('./.github/scripts/create-drift-issue.js');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,12 @@ jobs:
     
     steps:
     - name: 📥 Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0 # Fetch full history for changelog
         
     - name: ⚙️ Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
         

--- a/BicepGuard.csproj
+++ b/BicepGuard.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.CommandLine" Version="2.0.3" />
+    <PackageReference Include="System.CommandLine" Version="2.0.5" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/tests/BicepGuard.Tests/BicepGuard.Tests.csproj
+++ b/tests/BicepGuard.Tests/BicepGuard.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="FluentAssertions" Version="8.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Consolidates 8 open Dependabot PRs (#323, #324, #328, #333, #334, #335, #336, #337) into a single PR, plus pins all GitHub Actions to commit SHAs.

## NuGet updates
- `System.CommandLine` 2.0.3 → 2.0.5
- `FluentAssertions` 8.8.0 → 8.9.0

## GitHub Actions version updates
- `actions/github-script` v8 → v9
- `docker/login-action` v3.7.0 → v4
- `azure/login` v2 → v3
- `actions/upload-artifact` v6 → v7

## GitHub Actions SHA pinning
Replaces all remaining mutable version tags with pinned commit SHAs across all workflow files to prevent supply chain attacks.

## Closes
Supersedes #323, #324, #328, #333, #334, #335, #336, #337