### PR TITLE
docs: fix clone URL placeholder in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ docker run --rm \
 
 **Installation:**
 ```bash
-git clone <your-repo>
+git clone https://github.com/mwhooo/bicepguard.git
 cd bicepguard
 dotnet build
 ```


### PR DESCRIPTION
Replaces the `<your-repo>` placeholder in the Native Installation section with the actual repository URL.