### PR TITLE
⚙️(deps): Bump github/codeql-action/{init,analyze} from 4.37.1 to 4.37.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         dotnet list BicepGuard.csproj package --deprecated || true
         
     - name: 🛡️ Initialize CodeQL
-      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         languages: csharp
       continue-on-error: true
@@ -123,7 +123,7 @@ jobs:
       run: dotnet build BicepGuard.csproj --configuration Release --no-restore
       
     - name: 🔍 Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         category: "/language:csharp"
       continue-on-error: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ jobs:
         dotnet-version: '8.0.x'
 
     - name: 🛡️ Initialize CodeQL
-      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         languages: ${{ matrix.language }}
         # Override default queries with security-focused ones
@@ -46,7 +46,7 @@ jobs:
       run: dotnet build BicepGuard.csproj --configuration Release --no-restore
 
     - name: 🔍 Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
       with:
         category: "/language:${{matrix.language}}"
 


### PR DESCRIPTION
Combines Dependabot PRs #377 and #378 — bumps both `init` and `analyze` actions together to avoid the version mismatch that caused CodeQL analysis failures in the individual PRs.

- `github/codeql-action/init`: `7188fc3` → `e4fba86` (v4.37.3)
- `github/codeql-action/analyze`: `7188fc3` → `e4fba86` (v4.37.3)